### PR TITLE
fix: refetching queries

### DIFF
--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -7,7 +7,9 @@ import { Provider as ReduxProvider } from 'react-redux';
 import { store } from './store';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { refetchOnWindowFocus: false } },
+});
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement

--- a/ui/src/views/home/list.tsx
+++ b/ui/src/views/home/list.tsx
@@ -14,7 +14,7 @@ export const ListSites = () => {
     <Flex gap={10} mt="40px" flexWrap="wrap" justifyContent="center">
       {new Array(data).fill(0).map((_, index) => {
         const id = data - index - 1;
-        return <SiteCard tokenId={id} />;
+        return <SiteCard key={id} tokenId={id} />;
       })}
     </Flex>
   );


### PR DESCRIPTION
- Set `refetchOnWindowFocus: false` so it won't refetch all the time
- Fix warning on console due missing key on list child