### PR TITLE
chore: add cli variable to initialize new proxy

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -3,6 +3,7 @@
 ## Folder Structure
 
 Inside contracts you are going to find:
+
 - [contracts](./contracts): all the developed contracts
 - [deployments](./deployments): resultant ABI and info for deployments (each network will have a nested folder)
 - [lib](./lib): external modules used by Foundry
@@ -23,7 +24,7 @@ The contracts present in this project are based in [Solidity](https://github.com
 
 > ⚠️ Before starting developing make sure you Solidity, Node.js and yarn correctly installed in your environment
 
-Also, make sure you run `yarn` at the root directory to get some required tools.  The rest of these steps assume you are in the [contracts folder](./).
+Also, make sure you run `yarn` at the root directory to get some required tools. The rest of these steps assume you are in the [contracts folder](./).
 
 Follow the steps:
 
@@ -152,6 +153,23 @@ $ yarn deploy:mumbai
 ```
 
 to deploy the contract on the testnet. Please note that your wallet needs to hold enough Mumbai MATIC for the deployment to be successful. To reach more in-depth information about how to deploy contract checkout [this guide](https://wiki.polygon.technology/docs/develop/alchemy).
+
+### **Deploy arguments**
+
+For any of the deploy scripts above you are able to input arguments to change the date sent during the deployment. They are:
+
+| Argument             | Description                               | Example                    | Default   |
+| -------------------- | ----------------------------------------- | -------------------------- | --------- |
+| --new-proxy-instance | Force to deploy a new proxy instance      | --new-proxy-instance       | false     |
+| --name               | The collection name                       | --name "Fleek NFAs"        | FleekNFAs |
+| --symbol             | The collection symbol                     | --symbol "FKNFA"           | FLKNFA    |
+| --billing            | The billing values in an array of numbers | --billing "[10000, 20000]" | []        |
+
+Appending all of them together would be like:
+
+```
+$ yarn deploy:hardhat --new-proxy-instance --name "Fleek NFAs" --symbol "FKNFA" --billing "[10000, 20000]"
+```
 
 <!-- TODO: add this section after the mainnet setup is done and tested
 **Polygon main-net**

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -8,6 +8,8 @@ import 'hardhat-contract-sizer';
 import '@openzeppelin/hardhat-upgrades';
 import * as dotenv from 'dotenv';
 import { HardhatUserConfig } from 'hardhat/types';
+import { task, types } from 'hardhat/config';
+import deploy from './scripts/deploy';
 
 dotenv.config();
 
@@ -65,3 +67,16 @@ const config: HardhatUserConfig = {
 };
 
 export default config;
+
+// npx hardhat deploy --network mumbai --new-proxy-instance --name "FleekNFAs" --symbol "FLKNFA" --billing "[10000, 20000]"
+task('deploy', 'Deploy the contracts')
+  .addFlag('newProxyInstance', 'Force to deploy a new proxy instance')
+  .addOptionalParam('name', 'The collection name', 'FleekNFAs', types.string)
+  .addOptionalParam('symbol', 'The collection symbol', 'FLKNFA', types.string)
+  .addOptionalParam(
+    'billing',
+    'The billing values in an array of numbers like "[10000, 20000]"',
+    [],
+    types.json
+  )
+  .setAction(deploy);

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -9,8 +9,8 @@
     "test:hardhat": "hardhat test",
     "format": "prettier --write \"./**/*.{js,json,sol,ts}\"",
     "node:hardhat": "hardhat node",
-    "deploy:hardhat": "hardhat run scripts/deploy.js --network hardhat",
-    "deploy:mumbai": "hardhat run scripts/deploy.js --network mumbai",
+    "deploy:hardhat": "hardhat deploy --network hardhat",
+    "deploy:mumbai": "hardhat deploy --network mumbai",
     "compile": "hardhat compile",
     "verify:mumbai": "npx hardhat run ./scripts/verify-polyscan.js --network mumbai"
   },

--- a/contracts/scripts/deploy.js
+++ b/contracts/scripts/deploy.js
@@ -4,22 +4,14 @@ const {
 } = require('./utils/deploy-store');
 const { getProxyAddress, proxyStore } = require('./utils/proxy-store');
 
-// --- Inputs ---
-const ARGUMENTS = [
-  'FleekNFAs', // Collection name
-  'FLKNFA', // Collection symbol
-  [], // Billing values
-];
-
 // --- Script Settings ---
 const CONTRACT_NAME = 'FleekERC721';
-const NETWORK = hre.network.name;
 const DEFAULT_PROXY_SETTINGS = {
   unsafeAllow: ['external-library-linking'],
 };
 const LIBRARIES_TO_DEPLOY = ['FleekSVG'];
 
-const libraryDeployment = async () => {
+const libraryDeployment = async (hre) => {
   console.log('Deploying Libraries...');
   const libraries = {};
 
@@ -33,7 +25,7 @@ const libraryDeployment = async () => {
     const libContract = await hre.ethers.getContractFactory(lib);
     const libInstance = await libContract.deploy();
     await libInstance.deployed();
-    deployStore(NETWORK, lib, libInstance);
+    deployStore(hre.network.name, lib, libInstance);
     console.log(`Library "${lib}" deployed at ${libInstance.address}`);
     libraries[lib] = libInstance.address;
   }
@@ -41,55 +33,70 @@ const libraryDeployment = async () => {
   return libraries;
 };
 
-const main = async () => {
-  console.log(':: Starting Deployment ::');
-  console.log('Network:', NETWORK);
-  console.log('Contract:', CONTRACT_NAME);
+module.exports = async (taskArgs, hre) => {
+  const { newProxyInstance, name, symbol, billing } = taskArgs;
+  const network = hre.network.name;
 
-  const libraries = await libraryDeployment();
+  console.log(':: Starting Deployment ::');
+  console.log('Network:', network);
+  console.log('Contract:', CONTRACT_NAME);
+  console.log(':: Arguments ::');
+  console.log(taskArgs);
+  console.log();
+
+  const arguments = [name, symbol, billing];
+
+  const libraries = await libraryDeployment(hre);
 
   const Contract = await ethers.getContractFactory(CONTRACT_NAME, {
     libraries,
   });
-  const proxyAddress = await getProxyAddress(CONTRACT_NAME, NETWORK);
+  const proxyAddress = await getProxyAddress(CONTRACT_NAME, network);
 
   let deployResult;
 
   try {
-    if (!proxyAddress) throw new Error('No proxy address found');
+    if (!proxyAddress || newProxyInstance)
+      throw new Error('new-proxy-instance');
     console.log(`Trying to upgrade proxy contract at: "${proxyAddress}"`);
     deployResult = await upgrades.upgradeProxy(
       proxyAddress,
       Contract,
       DEFAULT_PROXY_SETTINGS
     );
+
+    console.log('\x1b[32m');
     console.log(
       `Contract ${CONTRACT_NAME} upgraded at "${deployResult.address}" by account "${deployResult.signer.address}"`
     );
-    await deployStore(NETWORK, CONTRACT_NAME, deployResult);
+    console.log('\x1b[0m');
+    await deployStore(network, CONTRACT_NAME, deployResult);
   } catch (e) {
     if (
-      e.message === 'No proxy address found' ||
+      e.message === 'new-proxy-instance' ||
       e.message.includes("doesn't look like an ERC 1967 proxy")
     ) {
       console.log(`Failed to upgrade proxy contract: "${e.message?.trim()}"`);
       console.log('Creating new proxy contract...');
       deployResult = await upgrades.deployProxy(
         Contract,
-        ARGUMENTS,
+        arguments,
         DEFAULT_PROXY_SETTINGS
       );
       await deployResult.deployed();
-      await proxyStore(CONTRACT_NAME, deployResult.address, hre.network.name);
+      await proxyStore(CONTRACT_NAME, deployResult.address, network);
+
+      console.log('\x1b[32m');
       console.log(
         `Contract ${CONTRACT_NAME} deployed at "${deployResult.address}" by account "${deployResult.signer.address}"`
       );
+      console.log('\x1b[0m');
     } else {
       throw e;
     }
 
     try {
-      await deployStore(NETWORK, CONTRACT_NAME, deployResult);
+      await deployStore(network, CONTRACT_NAME, deployResult);
     } catch (e) {
       console.error('Could not write deploy files', e);
     }
@@ -97,5 +104,3 @@ const main = async () => {
 
   return deployResult;
 };
-
-main();


### PR DESCRIPTION
```
➜  contracts git:(chore/sc-580/add-cli-variable-to-initialize-new-proxy) yarn deploy:hardhat --new-proxy-instance --name "Fleek NFAs" --symbol "FKNFA" --billing "[10000, 20000]"
yarn run v1.22.19
$ hardhat deploy --network hardhat --new-proxy-instance --name 'Fleek NFAs' --symbol FKNFA --billing '[10000, 20000]'
:: Starting Deployment ::
Network: hardhat
Contract: FleekERC721
:: Arguments ::
{
  newProxyInstance: true,
  name: 'Fleek NFAs',
  symbol: 'FKNFA',
  billing: [ 10000, 20000 ]
}

Deploying Libraries...
Library "FleekSVG" already deployed at 0x5FbDB2315678afecb367f032d93F642f64180aa3
Failed to upgrade proxy contract: "new-proxy-instance"
Creating new proxy contract...
Warning: Potentially unsafe deployment of contracts/FleekERC721.sol:FleekERC721

    You are using the `unsafeAllow.external-library-linking` flag to include external libraries.
    Make sure you have manually checked that the linked libraries are upgrade safe.

Duplicate definition of MetadataUpdate (MetadataUpdate(uint256,string,string,address), MetadataUpdate(uint256,string,uint24,address), MetadataUpdate(uint256,string,string[2],address), MetadataUpdate(uint256,string,bool,address))
Duplicate definition of MetadataUpdate (MetadataUpdate(uint256,string,string,address), MetadataUpdate(uint256,string,uint24,address), MetadataUpdate(uint256,string,string[2],address), MetadataUpdate(uint256,string,bool,address))
Writing proxy file /Users/felipemendes/fleek/non-fungible-apps/contracts/deployments/hardhat/proxy.json

Contract FleekERC721 deployed at "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0" by account "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"

Writing deploy files /Users/felipemendes/fleek/non-fungible-apps/contracts/deployments/hardhat/FleekERC721.json
✨  Done in 1.66s.
```